### PR TITLE
feat: RP Adapter Assemblies (#33)

### DIFF
--- a/Packages/com.irsiksoftware.logsmith/Runtime.BuiltIn.meta
+++ b/Packages/com.irsiksoftware.logsmith/Runtime.BuiltIn.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e94e8bdf4726455408d04c343c5ba680
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.irsiksoftware.logsmith/Runtime.BuiltIn/BuiltInRenderPipelineAdapter.cs
+++ b/Packages/com.irsiksoftware.logsmith/Runtime.BuiltIn/BuiltInRenderPipelineAdapter.cs
@@ -1,0 +1,33 @@
+namespace IrsikSoftware.LogSmith.BuiltIn
+{
+    /// <summary>
+    /// Adapter for Built-in Render Pipeline.
+    /// Provides render pipeline-specific logging capabilities when neither URP nor HDRP is present.
+    /// </summary>
+    public class BuiltInRenderPipelineAdapter
+    {
+        /// <summary>
+        /// Gets whether the Built-in Render Pipeline is active.
+        /// Returns true only when URP and HDRP are not available.
+        /// </summary>
+        public static bool IsActive
+        {
+            get
+            {
+#if !LOGSMITH_URP_AVAILABLE && !LOGSMITH_HDRP_AVAILABLE
+                return true;
+#else
+                return false;
+#endif
+            }
+        }
+
+        /// <summary>
+        /// Initializes the Built-in Render Pipeline adapter.
+        /// </summary>
+        public void Initialize()
+        {
+            // Future implementation: register built-in RP-specific sinks or hooks
+        }
+    }
+}

--- a/Packages/com.irsiksoftware.logsmith/Runtime.BuiltIn/BuiltInRenderPipelineAdapter.cs.meta
+++ b/Packages/com.irsiksoftware.logsmith/Runtime.BuiltIn/BuiltInRenderPipelineAdapter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 45284522d64561b4da81e2c5b0117872

--- a/Packages/com.irsiksoftware.logsmith/Runtime.BuiltIn/IrsikSoftware.LogSmith.BuiltIn.asmdef
+++ b/Packages/com.irsiksoftware.logsmith/Runtime.BuiltIn/IrsikSoftware.LogSmith.BuiltIn.asmdef
@@ -1,0 +1,27 @@
+{
+    "name": "IrsikSoftware.LogSmith.BuiltIn",
+    "rootNamespace": "IrsikSoftware.LogSmith.BuiltIn",
+    "references": [
+        "IrsikSoftware.LogSmith"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.render-pipelines.universal",
+            "expression": "",
+            "define": "LOGSMITH_URP_AVAILABLE"
+        },
+        {
+            "name": "com.unity.render-pipelines.high-definition",
+            "expression": "",
+            "define": "LOGSMITH_HDRP_AVAILABLE"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/Packages/com.irsiksoftware.logsmith/Runtime.BuiltIn/IrsikSoftware.LogSmith.BuiltIn.asmdef.meta
+++ b/Packages/com.irsiksoftware.logsmith/Runtime.BuiltIn/IrsikSoftware.LogSmith.BuiltIn.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e8f202e6d8932894580593ec61693e4a
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.irsiksoftware.logsmith/Runtime.HDRP.meta
+++ b/Packages/com.irsiksoftware.logsmith/Runtime.HDRP.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0b0c8a3e9677c7f45aa99930aa298967
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.irsiksoftware.logsmith/Runtime.HDRP/HDRPAdapter.cs
+++ b/Packages/com.irsiksoftware.logsmith/Runtime.HDRP/HDRPAdapter.cs
@@ -1,0 +1,32 @@
+namespace IrsikSoftware.LogSmith.HDRP
+{
+    /// <summary>
+    /// Adapter for High Definition Render Pipeline (HDRP).
+    /// Provides HDRP-specific logging capabilities when the HDRP package is present.
+    /// </summary>
+    public class HDRPAdapter
+    {
+        /// <summary>
+        /// Gets whether the High Definition Render Pipeline is available.
+        /// </summary>
+        public static bool IsAvailable
+        {
+            get
+            {
+#if LOGSMITH_HDRP_PRESENT
+                return true;
+#else
+                return false;
+#endif
+            }
+        }
+
+        /// <summary>
+        /// Initializes the HDRP adapter.
+        /// </summary>
+        public void Initialize()
+        {
+            // Future implementation: register HDRP-specific sinks or hooks
+        }
+    }
+}

--- a/Packages/com.irsiksoftware.logsmith/Runtime.HDRP/HDRPAdapter.cs.meta
+++ b/Packages/com.irsiksoftware.logsmith/Runtime.HDRP/HDRPAdapter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 491fab854073ae043af689da2ca8b0c0

--- a/Packages/com.irsiksoftware.logsmith/Runtime.HDRP/IrsikSoftware.LogSmith.HDRP.asmdef
+++ b/Packages/com.irsiksoftware.logsmith/Runtime.HDRP/IrsikSoftware.LogSmith.HDRP.asmdef
@@ -1,0 +1,22 @@
+{
+    "name": "IrsikSoftware.LogSmith.HDRP",
+    "rootNamespace": "IrsikSoftware.LogSmith.HDRP",
+    "references": [
+        "IrsikSoftware.LogSmith"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.render-pipelines.high-definition",
+            "expression": "",
+            "define": "LOGSMITH_HDRP_PRESENT"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/Packages/com.irsiksoftware.logsmith/Runtime.HDRP/IrsikSoftware.LogSmith.HDRP.asmdef.meta
+++ b/Packages/com.irsiksoftware.logsmith/Runtime.HDRP/IrsikSoftware.LogSmith.HDRP.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2fd183347ab87ee43beb2c727fa1e4af
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.irsiksoftware.logsmith/Runtime.URP.meta
+++ b/Packages/com.irsiksoftware.logsmith/Runtime.URP.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2aed2eab78cee9b4aaa1536c53452426
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.irsiksoftware.logsmith/Runtime.URP/IrsikSoftware.LogSmith.URP.asmdef
+++ b/Packages/com.irsiksoftware.logsmith/Runtime.URP/IrsikSoftware.LogSmith.URP.asmdef
@@ -1,0 +1,22 @@
+{
+    "name": "IrsikSoftware.LogSmith.URP",
+    "rootNamespace": "IrsikSoftware.LogSmith.URP",
+    "references": [
+        "IrsikSoftware.LogSmith"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.render-pipelines.universal",
+            "expression": "",
+            "define": "LOGSMITH_URP_PRESENT"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/Packages/com.irsiksoftware.logsmith/Runtime.URP/IrsikSoftware.LogSmith.URP.asmdef.meta
+++ b/Packages/com.irsiksoftware.logsmith/Runtime.URP/IrsikSoftware.LogSmith.URP.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ccfb13d4b7df1e645994815aad1f37d1
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.irsiksoftware.logsmith/Runtime.URP/URPAdapter.cs
+++ b/Packages/com.irsiksoftware.logsmith/Runtime.URP/URPAdapter.cs
@@ -1,0 +1,32 @@
+namespace IrsikSoftware.LogSmith.URP
+{
+    /// <summary>
+    /// Adapter for Universal Render Pipeline (URP).
+    /// Provides URP-specific logging capabilities when the URP package is present.
+    /// </summary>
+    public class URPAdapter
+    {
+        /// <summary>
+        /// Gets whether the Universal Render Pipeline is available.
+        /// </summary>
+        public static bool IsAvailable
+        {
+            get
+            {
+#if LOGSMITH_URP_PRESENT
+                return true;
+#else
+                return false;
+#endif
+            }
+        }
+
+        /// <summary>
+        /// Initializes the URP adapter.
+        /// </summary>
+        public void Initialize()
+        {
+            // Future implementation: register URP-specific sinks or hooks
+        }
+    }
+}

--- a/Packages/com.irsiksoftware.logsmith/Runtime.URP/URPAdapter.cs.meta
+++ b/Packages/com.irsiksoftware.logsmith/Runtime.URP/URPAdapter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 72f0a845bf8108743b4bad9cc4cc5282


### PR DESCRIPTION
## Summary
- Created three separate assemblies for render pipeline support
- IrsikSoftware.LogSmith.BuiltIn (active when URP/HDRP absent)
- IrsikSoftware.LogSmith.URP (conditionally compiled with URP)
- IrsikSoftware.LogSmith.HDRP (conditionally compiled with HDRP)

## Implementation Notes
Each assembly:
- Has its own .asmdef with version defines for SRP package detection
- References core LogSmith assembly only
- Provides placeholder adapter class for future RP-specific features
- Compiles independently without forcing SRP package dependencies

Version defines:
- LOGSMITH_URP_AVAILABLE/PRESENT: Set when com.unity.render-pipelines.universal exists
- LOGSMITH_HDRP_AVAILABLE/PRESENT: Set when com.unity.render-pipelines.high-definition exists

## Test Plan
- [x] Build passes (Unity compilation successful)
- [x] All assemblies compile independently
- [x] Core package has no SRP dependencies
- [x] Tests pass (272/289, same pre-existing failures as main)

## Acceptance Checklist
- [x] IrsikSoftware.LogSmith.BuiltIn assembly created
- [x] IrsikSoftware.LogSmith.URP assembly created
- [x] IrsikSoftware.LogSmith.HDRP assembly created
- [x] Each assembly has proper version defines
- [x] Core package remains SRP-agnostic

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)