### PR TITLE
fix: Remove cyclic assembly dependency (GH-68)

### DIFF
--- a/Packages/com.irsiksoftware.logsmith/Runtime/IrsikSoftware.LogSmith.asmdef
+++ b/Packages/com.irsiksoftware.logsmith/Runtime/IrsikSoftware.LogSmith.asmdef
@@ -5,10 +5,7 @@
         "Unity.Logging",
         "Unity.Burst",
         "Unity.Collections",
-        "VContainer",
-        "IrsikSoftware.LogSmith.BuiltIn",
-        "IrsikSoftware.LogSmith.URP",
-        "IrsikSoftware.LogSmith.HDRP"
+        "VContainer"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
## Summary
- Removed cyclic dependency between Runtime and RP adapter assemblies
- Refactored RenderPipelineAdapterService to use reflection for runtime type loading
- Runtime assembly no longer references BuiltIn/URP/HDRP assemblies at compile-time

## Problem
The project had a cyclic assembly dependency:
- `IrsikSoftware.LogSmith` (Runtime) referenced `IrsikSoftware.LogSmith.BuiltIn`, `IrsikSoftware.LogSmith.URP`, `IrsikSoftware.LogSmith.HDRP`
- Each RP adapter assembly referenced `IrsikSoftware.LogSmith` back
- This caused "cyclic dependencies detected" compiler errors, blocking all compilation

## Implementation Notes
- Used `Type.GetType()` with assembly-qualified names for dynamic type loading
- Adapters are instantiated via `Activator.CreateInstance()`
- Methods and properties accessed via reflection (`MethodInfo`, `PropertyInfo`)
- Maintains identical runtime behavior - adapters still loaded based on detected pipeline
- Error handling added for missing types/methods

## Test Plan
- [x] `run-build.ps1` completes successfully (no cyclic dependency errors)
- [x] 272/289 tests pass (17 pre-existing failures unrelated to this change)
- [x] Build output shows no compiler errors
- [x] Runtime type loading functions correctly

## Acceptance Checklist
- [x] No cyclic dependency errors
- [x] Build completes successfully
- [x] Existing tests pass (no new failures introduced)

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)