### PR TITLE
feat: Add performance benchmarks for LogRouter (GH-21)

### DIFF
--- a/Packages/com.irsiksoftware.logsmith/Tests/PlayMode/LogRouterPlayModePerformanceTests.cs
+++ b/Packages/com.irsiksoftware.logsmith/Tests/PlayMode/LogRouterPlayModePerformanceTests.cs
@@ -1,0 +1,204 @@
+using NUnit.Framework;
+using IrsikSoftware.LogSmith;
+using IrsikSoftware.LogSmith.Core;
+using System;
+using System.Collections;
+using System.Diagnostics;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace IrsikSoftware.LogSmith.Tests.PlayMode
+{
+    /// <summary>
+    /// PlayMode performance tests for LogRouter to validate real-world runtime performance.
+    /// Part of issue #21: Performance Budget & Benchmarks
+    /// Target: < 0.2ms/frame at 1k msgs/sec (< 200µs per message)
+    /// </summary>
+    [TestFixture]
+    public class LogRouterPlayModePerformanceTests
+    {
+        private LogRouter _router;
+        private TestSink _sink;
+        private LogMessage _testMessage;
+
+        [SetUp]
+        public void Setup()
+        {
+            _router = new LogRouter();
+            _sink = new TestSink();
+            _router.RegisterSink(_sink);
+            _testMessage = CreateTestMessage();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _router = null;
+            _sink = null;
+        }
+
+        private LogMessage CreateTestMessage()
+        {
+            return new LogMessage
+            {
+                Level = LogLevel.Info,
+                Category = "Performance",
+                Message = "PlayMode performance test message",
+                Timestamp = DateTime.UtcNow,
+                Frame = Time.frameCount,
+                ThreadId = System.Threading.Thread.CurrentThread.ManagedThreadId,
+                ThreadName = "Main"
+            };
+        }
+
+        [UnityTest]
+        public IEnumerator RuntimeRouting_SingleSink_CompletesUnder200Microseconds()
+        {
+            // Arrange
+            const int iterations = 1000;
+            yield return null; // Wait one frame to ensure Unity is ready
+
+            // Act
+            var stopwatch = Stopwatch.StartNew();
+            for (int i = 0; i < iterations; i++)
+            {
+                _router.Route(_testMessage);
+            }
+            stopwatch.Stop();
+
+            // Assert
+            var averageMicroseconds = (stopwatch.Elapsed.TotalMilliseconds * 1000.0) / iterations;
+            Assert.Less(averageMicroseconds, 200.0,
+                $"PlayMode routing took {averageMicroseconds:F2}µs average, expected < 200µs");
+
+            UnityEngine.Debug.Log($"[PERF][PlayMode] Single sink routing: {averageMicroseconds:F2}µs average ({iterations} iterations)");
+        }
+
+        [UnityTest]
+        public IEnumerator RuntimeRouting_HighThroughput_MaintainsFrameBudget()
+        {
+            // Arrange - Simulate 1000 messages/second
+            const int messagesPerFrame = 1000;
+            yield return null; // Wait one frame
+
+            // Act
+            var stopwatch = Stopwatch.StartNew();
+            for (int i = 0; i < messagesPerFrame; i++)
+            {
+                _router.Route(_testMessage);
+            }
+            stopwatch.Stop();
+
+            // Assert - Must stay under 0.2ms/frame budget
+            var totalMilliseconds = stopwatch.Elapsed.TotalMilliseconds;
+            Assert.Less(totalMilliseconds, 0.2,
+                $"PlayMode high throughput took {totalMilliseconds:F2}ms, expected < 0.2ms/frame");
+
+            UnityEngine.Debug.Log($"[PERF][PlayMode] High throughput: {totalMilliseconds:F2}ms for {messagesPerFrame} messages");
+        }
+
+        [UnityTest]
+        public IEnumerator RuntimeRouting_MultipleSinks_MeetsPerformanceTarget()
+        {
+            // Arrange
+            const int iterations = 1000;
+            var sink2 = new TestSink();
+            var sink3 = new TestSink();
+            _router.RegisterSink(sink2);
+            _router.RegisterSink(sink3);
+            yield return null;
+
+            // Act
+            var stopwatch = Stopwatch.StartNew();
+            for (int i = 0; i < iterations; i++)
+            {
+                _router.Route(_testMessage);
+            }
+            stopwatch.Stop();
+
+            // Assert
+            var averageMicroseconds = (stopwatch.Elapsed.TotalMilliseconds * 1000.0) / iterations;
+            Assert.Less(averageMicroseconds, 500.0,
+                $"PlayMode multi-sink routing took {averageMicroseconds:F2}µs average, expected < 500µs");
+
+            UnityEngine.Debug.Log($"[PERF][PlayMode] Multi sink routing (3 sinks): {averageMicroseconds:F2}µs average");
+        }
+
+        [UnityTest]
+        public IEnumerator RuntimeRouting_WithFiltering_FastRejection()
+        {
+            // Arrange
+            const int iterations = 1000;
+            _router.SetGlobalMinimumLevel(LogLevel.Error); // Filter out Info messages
+            yield return null;
+
+            // Act
+            var stopwatch = Stopwatch.StartNew();
+            for (int i = 0; i < iterations; i++)
+            {
+                _router.Route(_testMessage); // Should be filtered out
+            }
+            stopwatch.Stop();
+
+            // Assert - Filtered messages should be very fast
+            var averageMicroseconds = (stopwatch.Elapsed.TotalMilliseconds * 1000.0) / iterations;
+            Assert.Less(averageMicroseconds, 100.0,
+                $"PlayMode filtered routing took {averageMicroseconds:F2}µs average, expected < 100µs");
+
+            UnityEngine.Debug.Log($"[PERF][PlayMode] Filtered routing: {averageMicroseconds:F2}µs average");
+        }
+
+        [UnityTest]
+        public IEnumerator RuntimeRouting_AcrossMultipleFrames_SustainedPerformance()
+        {
+            // Arrange - Test sustained performance over 10 frames
+            const int framesToTest = 10;
+            const int messagesPerFrame = 100;
+            var frameTimes = new float[framesToTest];
+
+            // Act
+            for (int frame = 0; frame < framesToTest; frame++)
+            {
+                var stopwatch = Stopwatch.StartNew();
+                for (int i = 0; i < messagesPerFrame; i++)
+                {
+                    _testMessage.Frame = Time.frameCount;
+                    _router.Route(_testMessage);
+                }
+                stopwatch.Stop();
+                frameTimes[frame] = (float)stopwatch.Elapsed.TotalMilliseconds;
+
+                yield return null; // Next frame
+            }
+
+            // Assert - Each frame should be under budget
+            for (int i = 0; i < framesToTest; i++)
+            {
+                Assert.Less(frameTimes[i], 0.2f,
+                    $"Frame {i} took {frameTimes[i]:F3}ms for {messagesPerFrame} messages, expected < 0.2ms");
+            }
+
+            var avgFrameTime = 0f;
+            foreach (var time in frameTimes) avgFrameTime += time;
+            avgFrameTime /= framesToTest;
+
+            UnityEngine.Debug.Log($"[PERF][PlayMode] Sustained performance: {avgFrameTime:F3}ms average over {framesToTest} frames");
+        }
+
+        /// <summary>
+        /// Minimal test sink for performance testing.
+        /// </summary>
+        private class TestSink : ILogSink
+        {
+            public string Name => "PlayModeTestSink";
+            public int WriteCount { get; private set; }
+
+            public void Write(LogMessage message)
+            {
+                WriteCount++;
+            }
+
+            public void Flush() { }
+        }
+    }
+}

--- a/Packages/com.irsiksoftware.logsmith/Tests/Runtime/LogRouterPerformanceTests.cs
+++ b/Packages/com.irsiksoftware.logsmith/Tests/Runtime/LogRouterPerformanceTests.cs
@@ -1,0 +1,305 @@
+using NUnit.Framework;
+using IrsikSoftware.LogSmith;
+using IrsikSoftware.LogSmith.Core;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace IrsikSoftware.LogSmith.Tests
+{
+    /// <summary>
+    /// Performance tests for LogRouter to ensure routing and dispatch operations meet performance budgets.
+    /// Part of issue #21: Performance Budget & Benchmarks
+    /// Target: < 0.2ms/frame at 1k msgs/sec (< 200µs per message)
+    /// </summary>
+    [TestFixture]
+    public class LogRouterPerformanceTests
+    {
+        private LogRouter _router;
+        private TestSink _sink;
+        private LogMessage _testMessage;
+
+        [SetUp]
+        public void Setup()
+        {
+            _router = new LogRouter();
+            _sink = new TestSink();
+            _router.RegisterSink(_sink);
+            _testMessage = CreateTestMessage();
+        }
+
+        private LogMessage CreateTestMessage()
+        {
+            return new LogMessage
+            {
+                Level = LogLevel.Info,
+                Category = "Performance",
+                Message = "Performance test message",
+                Timestamp = DateTime.UtcNow,
+                Frame = 100,
+                ThreadId = 1,
+                ThreadName = "Main"
+            };
+        }
+
+        [Test]
+        public void Route_SingleSink_CompletesUnder200Microseconds()
+        {
+            // Arrange
+            const int iterations = 1000;
+
+            // Act
+            var stopwatch = Stopwatch.StartNew();
+            for (int i = 0; i < iterations; i++)
+            {
+                _router.Route(_testMessage);
+            }
+            stopwatch.Stop();
+
+            // Assert - Must meet < 200µs per message target (< 0.2ms/frame at 1k msg/sec)
+            var averageMicroseconds = (stopwatch.Elapsed.TotalMilliseconds * 1000.0) / iterations;
+            Assert.Less(averageMicroseconds, 200.0,
+                $"Routing to single sink took {averageMicroseconds:F2}µs average, expected < 200µs (0.2ms target)");
+
+            UnityEngine.Debug.Log($"[PERF] Single sink routing: {averageMicroseconds:F2}µs average ({iterations} iterations)");
+        }
+
+        [Test]
+        public void Route_MultipleSinks_CompletesUnder500Microseconds()
+        {
+            // Arrange
+            const int iterations = 1000;
+            var sink2 = new TestSink();
+            var sink3 = new TestSink();
+            _router.RegisterSink(sink2);
+            _router.RegisterSink(sink3);
+
+            // Act
+            var stopwatch = Stopwatch.StartNew();
+            for (int i = 0; i < iterations; i++)
+            {
+                _router.Route(_testMessage);
+            }
+            stopwatch.Stop();
+
+            // Assert - Three sinks should still be reasonably fast
+            var averageMicroseconds = (stopwatch.Elapsed.TotalMilliseconds * 1000.0) / iterations;
+            Assert.Less(averageMicroseconds, 500.0,
+                $"Routing to 3 sinks took {averageMicroseconds:F2}µs average, expected < 500µs");
+
+            UnityEngine.Debug.Log($"[PERF] Multi sink routing (3 sinks): {averageMicroseconds:F2}µs average ({iterations} iterations)");
+        }
+
+        [Test]
+        public void Route_WithCategoryFilter_CompletesUnder250Microseconds()
+        {
+            // Arrange
+            const int iterations = 1000;
+            _router.SetCategoryFilter("Performance", LogLevel.Info);
+
+            // Act
+            var stopwatch = Stopwatch.StartNew();
+            for (int i = 0; i < iterations; i++)
+            {
+                _router.Route(_testMessage);
+            }
+            stopwatch.Stop();
+
+            // Assert - Filtering should have minimal overhead
+            var averageMicroseconds = (stopwatch.Elapsed.TotalMilliseconds * 1000.0) / iterations;
+            Assert.Less(averageMicroseconds, 250.0,
+                $"Routing with category filter took {averageMicroseconds:F2}µs average, expected < 250µs");
+
+            UnityEngine.Debug.Log($"[PERF] Filtered routing: {averageMicroseconds:F2}µs average ({iterations} iterations)");
+        }
+
+        [Test]
+        public void Route_WithGlobalMinimumLevel_CompletesUnder200Microseconds()
+        {
+            // Arrange
+            const int iterations = 1000;
+            _router.SetGlobalMinimumLevel(LogLevel.Info);
+
+            // Act
+            var stopwatch = Stopwatch.StartNew();
+            for (int i = 0; i < iterations; i++)
+            {
+                _router.Route(_testMessage);
+            }
+            stopwatch.Stop();
+
+            // Assert - Global minimum level check should be fast
+            var averageMicroseconds = (stopwatch.Elapsed.TotalMilliseconds * 1000.0) / iterations;
+            Assert.Less(averageMicroseconds, 200.0,
+                $"Routing with global minimum level took {averageMicroseconds:F2}µs average, expected < 200µs");
+
+            UnityEngine.Debug.Log($"[PERF] Global level routing: {averageMicroseconds:F2}µs average ({iterations} iterations)");
+        }
+
+        [Test]
+        public void Route_FilteredOut_CompletesUnder100Microseconds()
+        {
+            // Arrange
+            const int iterations = 1000;
+            _router.SetGlobalMinimumLevel(LogLevel.Error); // Filter out Info messages
+
+            // Act
+            var stopwatch = Stopwatch.StartNew();
+            for (int i = 0; i < iterations; i++)
+            {
+                _router.Route(_testMessage); // This should be filtered out
+            }
+            stopwatch.Stop();
+
+            // Assert - Filtered messages should be even faster (early exit)
+            var averageMicroseconds = (stopwatch.Elapsed.TotalMilliseconds * 1000.0) / iterations;
+            Assert.Less(averageMicroseconds, 100.0,
+                $"Routing filtered messages took {averageMicroseconds:F2}µs average, expected < 100µs (fast rejection)");
+
+            UnityEngine.Debug.Log($"[PERF] Filtered-out routing: {averageMicroseconds:F2}µs average ({iterations} iterations)");
+        }
+
+        [Test]
+        public void RegisterSink_CompletesUnder50Microseconds()
+        {
+            // Arrange
+            const int iterations = 1000;
+            var sinks = new List<TestSink>();
+            for (int i = 0; i < iterations; i++)
+            {
+                sinks.Add(new TestSink());
+            }
+
+            // Act
+            var stopwatch = Stopwatch.StartNew();
+            foreach (var sink in sinks)
+            {
+                _router.RegisterSink(sink);
+            }
+            stopwatch.Stop();
+
+            // Assert - Sink registration should be very fast
+            var averageMicroseconds = (stopwatch.Elapsed.TotalMilliseconds * 1000.0) / iterations;
+            Assert.Less(averageMicroseconds, 50.0,
+                $"Sink registration took {averageMicroseconds:F2}µs average, expected < 50µs");
+
+            UnityEngine.Debug.Log($"[PERF] Sink registration: {averageMicroseconds:F2}µs average ({iterations} iterations)");
+        }
+
+        [Test]
+        public void Subscribe_WithMainThreadDispatch_MeetsPerformanceTarget()
+        {
+            // Arrange
+            const int iterations = 1000;
+            int receivedCount = 0;
+            var subscription = _router.Subscribe(msg => { receivedCount++; });
+
+            // Act
+            var stopwatch = Stopwatch.StartNew();
+            for (int i = 0; i < iterations; i++)
+            {
+                _router.Route(_testMessage);
+            }
+            stopwatch.Stop();
+
+            // Assert - Subscription dispatch should not significantly impact routing performance
+            var averageMicroseconds = (stopwatch.Elapsed.TotalMilliseconds * 1000.0) / iterations;
+            Assert.Less(averageMicroseconds, 300.0,
+                $"Routing with subscription took {averageMicroseconds:F2}µs average, expected < 300µs");
+
+            UnityEngine.Debug.Log($"[PERF] Routing with subscription: {averageMicroseconds:F2}µs average ({iterations} iterations)");
+
+            subscription.Dispose();
+        }
+
+        [Test]
+        public void Route_HighThroughput_MaintainsPerformance()
+        {
+            // Arrange - Simulate 1000 messages/second for 1 second
+            const int messagesPerSecond = 1000;
+            const int durationSeconds = 1;
+            const int totalMessages = messagesPerSecond * durationSeconds;
+
+            // Act
+            var stopwatch = Stopwatch.StartNew();
+            for (int i = 0; i < totalMessages; i++)
+            {
+                _router.Route(_testMessage);
+            }
+            stopwatch.Stop();
+
+            // Assert - Must process 1000 msg/sec with < 0.2ms/frame budget
+            var totalMilliseconds = stopwatch.Elapsed.TotalMilliseconds;
+            var averageMicroseconds = (totalMilliseconds * 1000.0) / totalMessages;
+
+            Assert.Less(averageMicroseconds, 200.0,
+                $"High throughput (1k msg/sec) took {averageMicroseconds:F2}µs average, expected < 200µs");
+
+            Assert.Less(totalMilliseconds, durationSeconds * 1000 * 0.2,
+                $"Total time {totalMilliseconds:F2}ms exceeds 0.2ms/frame budget for {totalMessages} messages");
+
+            UnityEngine.Debug.Log($"[PERF] High throughput: {averageMicroseconds:F2}µs/msg, {totalMilliseconds:F2}ms total for {totalMessages} messages");
+        }
+
+        [Test]
+        public void Route_ConcurrentAccess_MaintainsThreadSafety()
+        {
+            // Arrange
+            const int threadCount = 4;
+            const int messagesPerThread = 250;
+            var threads = new System.Threading.Thread[threadCount];
+            var results = new double[threadCount];
+
+            // Act
+            for (int t = 0; t < threadCount; t++)
+            {
+                int threadIndex = t;
+                threads[t] = new System.Threading.Thread(() =>
+                {
+                    var stopwatch = Stopwatch.StartNew();
+                    for (int i = 0; i < messagesPerThread; i++)
+                    {
+                        _router.Route(_testMessage);
+                    }
+                    stopwatch.Stop();
+                    results[threadIndex] = (stopwatch.Elapsed.TotalMilliseconds * 1000.0) / messagesPerThread;
+                });
+                threads[t].Start();
+            }
+
+            for (int t = 0; t < threadCount; t++)
+            {
+                threads[t].Join();
+            }
+
+            // Assert - Concurrent routing should maintain performance
+            foreach (var avgMicroseconds in results)
+            {
+                Assert.Less(avgMicroseconds, 400.0,
+                    $"Concurrent routing took {avgMicroseconds:F2}µs average, expected < 400µs (accounts for lock contention)");
+            }
+
+            var overallAvg = 0.0;
+            foreach (var result in results) overallAvg += result;
+            overallAvg /= threadCount;
+
+            UnityEngine.Debug.Log($"[PERF] Concurrent routing ({threadCount} threads): {overallAvg:F2}µs average");
+        }
+
+        /// <summary>
+        /// Test sink that does minimal work (just counts messages).
+        /// </summary>
+        private class TestSink : ILogSink
+        {
+            public string Name => "TestSink";
+            public int WriteCount { get; private set; }
+
+            public void Write(LogMessage message)
+            {
+                WriteCount++;
+            }
+
+            public void Flush() { }
+        }
+    }
+}

--- a/Packages/com.irsiksoftware.logsmith/Tests/Runtime/LogRouterPerformanceTests.cs.meta
+++ b/Packages/com.irsiksoftware.logsmith/Tests/Runtime/LogRouterPerformanceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d77fb0f12f15b0b49bade4796cd8b869


### PR DESCRIPTION
## Summary
- Added comprehensive performance benchmarks for LogRouter to meet < 0.2ms/frame budget at 1k msgs/sec
- 9 EditMode micro-benchmarks validating routing, filtering, sink registration, and concurrent access
- 5 PlayMode runtime tests validating sustained frame-by-frame performance

## Implementation Notes
**EditMode Tests** (`LogRouterPerformanceTests.cs`):
- `Route_SingleSink_CompletesUnder200Microseconds` - Core routing performance (200µs target)
- `Route_MultipleSinks_CompletesUnder500Microseconds` - Multi-sink overhead
- `Route_WithCategoryFilter_CompletesUnder250Microseconds` - Filter overhead
- `Route_FilteredOut_CompletesUnder100Microseconds` - Fast rejection path
- `Route_HighThroughput_MaintainsPerformance` - 1k msg/sec sustained load
- `Route_ConcurrentAccess_MaintainsThreadSafety` - Multi-threaded performance
- `RegisterSink_CompletesUnder50Microseconds` - Sink registration speed
- Plus 2 more tests for global min level and subscriptions

**PlayMode Tests** (`LogRouterPlayModePerformanceTests.cs`):
- `RuntimeRouting_SingleSink_CompletesUnder200Microseconds` - Runtime routing validation
- `RuntimeRouting_HighThroughput_MaintainsFrameBudget` - Frame budget compliance
- `RuntimeRouting_MultipleSinks_MeetsPerformanceTarget` - Multi-sink runtime perf
- `RuntimeRouting_WithFiltering_FastRejection` - Filter fast-path in runtime
- `RuntimeRouting_AcrossMultipleFrames_SustainedPerformance` - Cross-frame stability

## Test Plan
- [x] Run `run-tests.ps1 -IssueNumber 21` 
- [x] Verify 8/9 EditMode perf tests passing (1 Subscribe test fails due to pre-existing Subscribe infra issue #50,52,53,54,55)
- [x] Core routing performance tests all passing
- [x] PlayMode tests created and staged for Unity meta generation

## Acceptance Checklist
- [x] Micro-benchmarks (Editor) committed ✓
- [x] PlayMode performance tests committed ✓
- [x] Targets met: < 200µs per message for single sink routing ✓
- [x] High throughput test validates 1k msg/sec budget ✓

Related: #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)