### PR TITLE
feat: Add Third Party Notices and complete Asset Store compliance (GH-29)

### DIFF
--- a/Packages/com.irsiksoftware.logsmith/Tests/PlayMode/DebugOverlayUITests.cs.meta
+++ b/Packages/com.irsiksoftware.logsmith/Tests/PlayMode/DebugOverlayUITests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6010c7b496e516d4e802d5e926f16836

--- a/Packages/com.irsiksoftware.logsmith/Third Party Notices.md
+++ b/Packages/com.irsiksoftware.logsmith/Third Party Notices.md
@@ -1,0 +1,102 @@
+# Third Party Notices
+
+LogSmith includes or depends upon the following third-party packages and libraries. Each package is used in accordance with its respective license.
+
+---
+
+## Unity Technologies Packages
+
+### com.unity.logging (v1.0.0+)
+- **Copyright**: © Unity Technologies
+- **License**: Unity Companion License
+- **Source**: https://docs.unity3d.com/Packages/com.unity.logging@latest
+- **Purpose**: Native Unity logging backend for LogSmith
+- **License URL**: https://unity.com/legal/licenses/unity-companion-license
+
+### com.unity.burst (v1.8.0+)
+- **Copyright**: © Unity Technologies
+- **License**: Unity Companion License
+- **Source**: https://docs.unity3d.com/Packages/com.unity.burst@latest
+- **Purpose**: High-performance code generation for logging operations
+- **License URL**: https://unity.com/legal/licenses/unity-companion-license
+
+### com.unity.collections (v2.1.0+)
+- **Copyright**: © Unity Technologies
+- **License**: Unity Companion License
+- **Source**: https://docs.unity3d.com/Packages/com.unity.collections@latest
+- **Purpose**: Native container types for efficient data structures
+- **License URL**: https://unity.com/legal/licenses/unity-companion-license
+
+---
+
+## Optional Third-Party Packages
+
+### VContainer (jp.hadashikick.vcontainer v1.17.0+)
+- **Copyright**: © hadashiA
+- **License**: MIT License
+- **Source**: https://github.com/hadashiA/VContainer
+- **Purpose**: Dependency injection container (optional integration)
+- **License URL**: https://github.com/hadashiA/VContainer/blob/master/LICENSE
+
+**VContainer MIT License:**
+
+```
+MIT License
+
+Copyright (c) 2020 hadashiA
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+---
+
+## Unity Companion License Summary
+
+Unity Companion License packages are provided by Unity Technologies and licensed exclusively for use with Unity software. Key terms:
+
+- Packages may only be used in conjunction with Unity software
+- Unity Technologies retains all rights, title, and interest in the packages
+- Packages are provided "as-is" without warranty
+- Full license text: https://unity.com/legal/licenses/unity-companion-license
+
+---
+
+## Additional Attributions
+
+LogSmith is built by **Irsik Software** and released under the MIT License.
+
+LogSmith does not include any proprietary Unity Editor tools, assets, or resources. All code is original or uses properly licensed third-party dependencies as listed above.
+
+---
+
+## Export Compliance
+
+LogSmith does not include encryption technology beyond standard TLS/HTTPS connections for optional HTTP sinks (user-configured). No export restrictions apply.
+
+---
+
+## Contact
+
+For questions regarding third-party licenses or attributions:
+- **GitHub Issues**: https://github.com/DakotaIrsik/LogSmith/issues
+- **Email**: support@irsiksoftware.com
+
+---
+
+*Last Updated: 2025-10-01*

--- a/Packages/com.irsiksoftware.logsmith/Third Party Notices.md.meta
+++ b/Packages/com.irsiksoftware.logsmith/Third Party Notices.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7b69a4e4132fe6b46b5c5334df61fa1a
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/scene-generation-log.txt
+++ b/scene-generation-log.txt
@@ -1,0 +1,536 @@
+[Licensing::Module] Trying to connect to existing licensing client channel...
+Built from '6000.2/staging' branch; Version is '6000.2.5f1 (43d04cd1df69) revision 4444236'; Using compiler version '194234433'; Build Type 'Release'
+OS: 'Windows 10  (10.0.19045) 64bit Professional' Language: 'en' Physical Memory: 65444 MB
+BatchMode: 1, IsHumanControllingUs: 0, StartBugReporterOnCrash: 0, Is64bit: 1
+[Licensing::IpcConnector] Successfully connected to: "LicenseClient-Ender" at "2025-10-01T11:24:04.7371274Z"
+Date: 2025-10-01T11:24:04Z
+
+COMMAND LINE ARGUMENTS:
+C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Unity.exe
+-quit
+-batchmode
+-nographics
+-projectPath
+C:\Code\LogSmith
+-executeMethod
+IrsikSoftware.LogSmith.Editor.SampleSceneGenerator.GenerateAllScenes
+-logFile
+C:\Code\LogSmith\scene-generation-log.txt
+Successfully changed project path to: C:\Code\LogSmith
+C:/Code/LogSmith
+[UnityMemory] Configuration Parameters - Can be set up in boot.config
+    "memorysetup-allocator-temp-initial-block-size-main=262144"
+    "memorysetup-allocator-temp-initial-block-size-worker=262144"
+    "memorysetup-bucket-allocator-granularity=16"
+    "memorysetup-bucket-allocator-bucket-count=8"
+    "memorysetup-bucket-allocator-block-size=33554432"
+    "memorysetup-bucket-allocator-block-count=8"
+    "memorysetup-main-allocator-block-size=16777216"
+    "memorysetup-thread-allocator-block-size=16777216"
+    "memorysetup-gfx-main-allocator-block-size=16777216"
+    "memorysetup-gfx-thread-allocator-block-size=16777216"
+    "memorysetup-cache-allocator-block-size=4194304"
+    "memorysetup-typetree-allocator-block-size=2097152"
+    "memorysetup-profiler-bucket-allocator-granularity=16"
+    "memorysetup-profiler-bucket-allocator-bucket-count=8"
+    "memorysetup-profiler-bucket-allocator-block-size=33554432"
+    "memorysetup-profiler-bucket-allocator-block-count=8"
+    "memorysetup-profiler-allocator-block-size=16777216"
+    "memorysetup-profiler-editor-allocator-block-size=1048576"
+    "memorysetup-temp-allocator-size-main=16777216"
+    "memorysetup-job-temp-allocator-block-size=2097152"
+    "memorysetup-job-temp-allocator-block-size-background=1048576"
+    "memorysetup-job-temp-allocator-reduction-small-platforms=262144"
+    "memorysetup-temp-allocator-size-background-worker=32768"
+    "memorysetup-temp-allocator-size-job-worker=262144"
+    "memorysetup-temp-allocator-size-preload-manager=33554432"
+    "memorysetup-temp-allocator-size-nav-mesh-worker=65536"
+    "memorysetup-temp-allocator-size-audio-worker=65536"
+    "memorysetup-temp-allocator-size-cloud-worker=32768"
+    "memorysetup-temp-allocator-size-gi-baking-worker=262144"
+    "memorysetup-temp-allocator-size-gi-baking-worker=262144"
+    "memorysetup-temp-allocator-size-gi-baking-worker=262144"
+    "memorysetup-temp-allocator-size-gi-baking-worker=262144"
+    "memorysetup-temp-allocator-size-gi-baking-worker=262144"
+    "memorysetup-temp-allocator-size-gfx=262144"
+Player connection [29972]  Target information:
+
+Player connection [29972]  * "[IP] 192.168.1.186 [Port] 55504 [Flags] 2 [Guid] 2826423384 [EditorId] 2826423384 [Version] 1048832 [Id] WindowsEditor(7,DESKTOP-02MAEJL) [Debug] 1 [PackageName] WindowsEditor [ProjectName] Editor" 
+
+Player connection [29972]  * "[IP] 172.17.192.1 [Port] 55504 [Flags] 2 [Guid] 2826423384 [EditorId] 2826423384 [Version] 1048832 [Id] WindowsEditor(7,DESKTOP-02MAEJL) [Debug] 1 [PackageName] WindowsEditor [ProjectName] Editor" 
+
+Player connection [29972] Host joined multi-casting on [225.0.0.222:54997]...
+Player connection [29972] Host joined alternative multi-casting on [225.0.0.222:34997]...
+Input System module state changed to: Initialized.
+[Physics::Module] Initialized fallback backend.
+[Physics::Module] Id: 0xdecafbad
+[Licensing::Client] Code 10 while verifying Licensing Client signature (process Id: 13884, path: "C:/Program Files/Unity Hub/UnityLicensingClient_V1/Unity.Licensing.Client.exe")
+[Licensing::Module] LicensingClient has failed validation; ignoring
+[Licensing::Client] Handshaking with LicensingClient:
+  Version:                 1.17.3+a4e98f1
+  Session Id:              c70f99d871ae432e9eff2962f881ebde
+  Correlation Id:          e552d1778095c2f6324542151d273179
+  External correlation Id: 3378653435086880057
+  Machine Id:              9VnBYQDP9/Ws5IOolBNy9qd7dI0=
+[Licensing::Module] Successfully connected to LicensingClient on channel: "LicenseClient-Ender" (connect: 0.00s, validation: 0.00s, handshake: 0.02s)
+[Licensing::IpcConnector] Successfully connected to: "LicenseClient-Ender-notifications" at "2025-10-01T11:24:04.762133Z"
+[Licensing::Module] Error: Access token is unavailable; failed to update
+[Licensing::Client] Successfully resolved entitlement details
+[Licensing::Module] License group:
+  Id: 2474278852306-UnityPersXXXX
+  Product: Unity Personal
+  Type: Assigned
+  Expiration: Unlimited
+[Licensing::Client] Successfully updated license, isAsync: True, time: 0.00
+[Licensing::Client] Successfully resolved entitlement details
+[Licensing::Module] Licensing Background thread has ended after 0.03s
+[Package Manager] Connected to IPC stream "Upm-28444" after 0.3 seconds.
+Library Redirect Path: Library/
+FMOD initialized on nosound output
+[Physics::Module] Selected backend.
+[Physics::Module] Name: PhysX
+[Physics::Module] Id: 0xf2b8ea05
+[Physics::Module] SDK Version: 4.1.2
+[Physics::Module] Integration Version: 1.0.0
+[Physics::Module] Threading Mode: Multi-Threaded
+Refreshing native plugins compatible for Editor in 0.29 ms, found 0 plugins.
+Preloading 0 native plugins for Editor in 0.00 ms.
+Initialize engine version: 6000.2.5f1 (43d04cd1df69)
+[Subsystems] Discovering subsystems at path C:/Program Files/Unity/Hub/Editor/6000.2.5f1/Editor/Data/Resources/UnitySubsystems
+[Subsystems] Discovering subsystems at path c:/Code/LogSmith/Assets
+Forcing GfxDevice: Null
+GfxDevice: creating device client; kGfxThreadingModeNonThreaded
+NullGfxDevice:
+    Version:  NULL 1.0 [1.0]
+    Renderer: Null Device
+    Vendor:   Unity Technologies
+Shader Hidden/ProbeVolume/VoxelizeScene is not supported: GPU does not support conservative rasterization
+Initialize mono
+Mono path[0] = 'C:/Program Files/Unity/Hub/Editor/6000.2.5f1/Editor/Data/Managed'
+Mono path[1] = 'C:/Program Files/Unity/Hub/Editor/6000.2.5f1/Editor/Data/MonoBleedingEdge/lib/mono/unityjit-win32'
+Mono config path = 'C:/Program Files/Unity/Hub/Editor/6000.2.5f1/Editor/Data/MonoBleedingEdge/etc'
+Using monoOptions --debugger-agent=transport=dt_socket,embedding=1,server=y,suspend=n,address=127.0.0.1:56444
+Using cacheserver namespaces - metadata:defaultmetadata, artifacts:defaultartifacts
+Using cacheserver namespaces - metadata:defaultmetadata, artifacts:defaultartifacts
+ImportWorker Server TCP listen port: 0
+AcceleratorClientConnectionCallback - disconnected - :0
+Begin MonoManager ReloadAssembly
+Registering precompiled unity dll's ...
+Register platform support module: C:/Program Files/Unity/Hub/Editor/6000.2.5f1/Editor/Data/PlaybackEngines/WindowsStandaloneSupport/UnityEditor.WindowsStandalone.Extensions.dll
+Registered in 0.001812 seconds.
+- Loaded All Assemblies, in  0.356 seconds
+Native extension for WindowsStandalone target not found
+Mono: successfully reloaded assembly
+- Finished resetting the current domain, in  0.311 seconds
+Domain Reload Profiling: 666ms
+	BeginReloadAssembly (118ms)
+		ExecutionOrderSort (0ms)
+		DisableScriptedObjects (0ms)
+		BackupInstance (0ms)
+		ReleaseScriptingObjects (0ms)
+		CreateAndSetChildDomain (1ms)
+	RebuildCommonClasses (36ms)
+	RebuildNativeTypeToScriptingClass (12ms)
+	initialDomainReloadingComplete (43ms)
+	LoadAllAssembliesAndSetupDomain (145ms)
+		LoadAssemblies (116ms)
+		RebuildTransferFunctionScriptingTraits (0ms)
+		AnalyzeDomain (142ms)
+			TypeCache.Refresh (141ms)
+				TypeCache.ScanAssembly (130ms)
+			BuildScriptInfoCaches (0ms)
+			ResolveRequiredComponents (0ms)
+	FinalizeReload (312ms)
+		ReleaseScriptCaches (0ms)
+		RebuildScriptCaches (0ms)
+		SetupLoadedEditorAssemblies (279ms)
+			LogAssemblyErrors (0ms)
+			InitializePlatformSupportModulesInManaged (46ms)
+			SetLoadedEditorAssemblies (4ms)
+			BeforeProcessingInitializeOnLoad (62ms)
+			ProcessInitializeOnLoadAttributes (116ms)
+			ProcessInitializeOnLoadMethodAttributes (52ms)
+			AfterProcessingInitializeOnLoad (0ms)
+			EditorAssembliesLoaded (0ms)
+		ExecutionOrderSort2 (0ms)
+		AwakeInstancesAfterBackupRestoration (0ms)
+[Licensing::Client] Successfully resolved entitlement details
+Application.AssetDatabase Initial Refresh Start
+Package Manager log level set to [2]
+[Package Manager] Restoring resolved packages state from cache
+[Licensing::Client] Successfully resolved entitlement details
+[Package Manager] Registered 59 packages:
+  Packages from [https://packages.unity.com]:
+    com.unity.ai.navigation@2.0.9 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.ai.navigation@5218e4bf7edc)
+    com.unity.collab-proxy@2.9.3 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.collab-proxy@ab839cc7d2ad)
+    com.unity.ide.rider@3.0.38 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.ide.rider@1f60b3138684)
+    com.unity.ide.visualstudio@2.0.23 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.ide.visualstudio@198cdf337d13)
+    com.unity.inputsystem@1.14.2 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.inputsystem@be6c4fd0abf5)
+    com.unity.timeline@1.8.9 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.timeline@6b9e48457ddb)
+    com.unity.visualscripting@1.9.7 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.visualscripting@6279e2b7c485)
+    com.unity.logging@1.3.10 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.logging@296add779e8a)
+    com.unity.burst@1.8.24 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.burst@f7a407abf4d5)
+    com.unity.collections@2.5.7 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.collections@d49facba0036)
+    com.unity.mathematics@1.3.2 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.mathematics@8017b507cc74)
+    com.unity.nuget.mono-cecil@1.11.5 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.nuget.mono-cecil@d78732e851eb)
+    com.unity.test-framework.performance@3.1.0 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.test-framework.performance@92d1d09a72ed)
+    com.unity.searcher@4.9.3 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.searcher@1e17ce91558d)
+  Built-in packages:
+    com.unity.multiplayer.center@1.0.0 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.multiplayer.center@f3fb577b3546)
+    com.unity.render-pipelines.universal@17.2.0 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.render-pipelines.universal@0d0962426023)
+    com.unity.test-framework@1.5.1 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.test-framework@038a2b0cacd2)
+    com.unity.ugui@2.0.0 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.ugui@38c58105e446)
+    com.unity.modules.accessibility@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.accessibility)
+    com.unity.modules.ai@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.ai)
+    com.unity.modules.androidjni@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.androidjni)
+    com.unity.modules.animation@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.animation)
+    com.unity.modules.assetbundle@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.assetbundle)
+    com.unity.modules.audio@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.audio)
+    com.unity.modules.cloth@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.cloth)
+    com.unity.modules.director@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.director)
+    com.unity.modules.imageconversion@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.imageconversion)
+    com.unity.modules.imgui@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.imgui)
+    com.unity.modules.jsonserialize@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.jsonserialize)
+    com.unity.modules.particlesystem@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.particlesystem)
+    com.unity.modules.physics@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.physics)
+    com.unity.modules.physics2d@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.physics2d)
+    com.unity.modules.screencapture@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.screencapture)
+    com.unity.modules.terrain@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.terrain)
+    com.unity.modules.terrainphysics@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.terrainphysics)
+    com.unity.modules.tilemap@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.tilemap)
+    com.unity.modules.ui@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.ui)
+    com.unity.modules.uielements@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.uielements)
+    com.unity.modules.umbra@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.umbra)
+    com.unity.modules.unityanalytics@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.unityanalytics)
+    com.unity.modules.unitywebrequest@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.unitywebrequest)
+    com.unity.modules.unitywebrequestassetbundle@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.unitywebrequestassetbundle)
+    com.unity.modules.unitywebrequestaudio@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.unitywebrequestaudio)
+    com.unity.modules.unitywebrequesttexture@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.unitywebrequesttexture)
+    com.unity.modules.unitywebrequestwww@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.unitywebrequestwww)
+    com.unity.modules.vehicles@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.vehicles)
+    com.unity.modules.video@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.video)
+    com.unity.modules.vr@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.vr)
+    com.unity.modules.wind@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.wind)
+    com.unity.modules.xr@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.xr)
+    com.unity.modules.subsystems@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.subsystems)
+    com.unity.modules.hierarchycore@1.0.0 (location: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Resources\PackageManager\BuiltInPackages\com.unity.modules.hierarchycore)
+    com.unity.ext.nunit@2.0.5 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.ext.nunit@031a54704bff)
+    com.unity.render-pipelines.core@17.2.0 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.render-pipelines.core@f2c863af5658)
+    com.unity.shadergraph@17.2.0 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.shadergraph@940512a5d7e1)
+    com.unity.render-pipelines.universal-config@17.0.3 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.render-pipelines.universal-config@8dc1aab4af1d)
+    com.unity.rendering.light-transport@1.0.1 (location: C:\Code\LogSmith\Library\PackageCache\com.unity.rendering.light-transport@2c9279f90d7c)
+  Embedded packages:
+    com.irsiksoftware.logsmith@file:C:\Code\LogSmith\Packages\com.irsiksoftware.logsmith (location: C:\Code\LogSmith\Packages\com.irsiksoftware.logsmith)
+  Git packages:
+    jp.hadashikick.vcontainer@https://github.com/hadashiA/VContainer.git?path=VContainer/Assets/VContainer#1.17.0 (location: C:\Code\LogSmith\Library\PackageCache\jp.hadashikick.vcontainer@8c70d0b94b30)
+[Subsystems] No new subsystems found in resolved package list.
+[Package Manager] Done registering packages in 0.01 seconds
+[ScriptCompilation] Requested script compilation because: Assetdatabase observed changes in script compilation related files
+info: Microsoft.Hosting.Lifetime[14]
+      Now listening on: http://localhost:80
+info: Microsoft.Hosting.Lifetime[0]
+      Application started. Press Ctrl+C to shut down.
+info: Microsoft.Hosting.Lifetime[0]
+      Hosting environment: Production
+info: Microsoft.Hosting.Lifetime[0]
+      Content root path: c:\Code\LogSmith\
+info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
+      Request starting HTTP/2 POST http://ilpp/UnityILPP.PostProcessing/Ping application/grpc -
+info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]
+      Executing endpoint 'gRPC - /UnityILPP.PostProcessing/Ping'
+info: Microsoft.AspNetCore.Routing.EndpointMiddleware[1]
+      Executed endpoint 'gRPC - /UnityILPP.PostProcessing/Ping'
+info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
+      Request finished HTTP/2 POST http://ilpp/UnityILPP.PostProcessing/Ping application/grpc - - 200 - application/grpc 31.8767ms
+Starting: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\bee_backend.exe --ipc --defer-dag-verification --dagfile="Library/Bee/1900b0aE.dag" --continue-on-failure --profile="Library/Bee/backend1.traceevents" ScriptAssemblies
+WorkingDir: c:/Code/LogSmith
+info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
+      Request starting HTTP/2 POST http://ilpp/UnityILPP.PostProcessing/ConfigurePostProcessors application/grpc -
+info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]
+      Executing endpoint 'gRPC - /UnityILPP.PostProcessing/ConfigurePostProcessors'
+warn: Unity.ILPP.Runner.PostProcessingAssemblyLoadContext[0]
+      Assembly system.runtime.interopservices.windowsruntime has duplicate hint path. Ignoring "C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\UnityReferenceAssemblies\unity-4.8-api\Facades\System.Runtime.InteropServices.WindowsRuntime.dll" in favor of "C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\NetStandard\Extensions\2.0.0\System.Runtime.InteropServices.WindowsRuntime.dll"
+DisplayProgressbar: Compiling Scripts
+warn: Unity.ILPP.Runner.PostProcessingAssemblyLoadContext[0]
+      Assembly system.componentmodel.composition has duplicate hint path. Ignoring "C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\UnityReferenceAssemblies\unity-4.8-api\System.ComponentModel.Composition.dll" in favor of "C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\NetStandard\compat\2.1.0\shims\netfx\System.ComponentModel.Composition.dll"
+info: Unity.ILPP.Runner.PostProcessingAssemblyLoadContext[0]
+      Resolved Unity.Burst.Cecil, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e with C:\Code\LogSmith\Library\PackageCache\com.unity.burst@f7a407abf4d5\Unity.Burst.CodeGen\Unity.Burst.Cecil.dll
+info: Unity.ILPP.Runner.PostProcessingAssemblyLoadContext[0]
+      Resolved Mono.Cecil, Version=0.11.5.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e with C:\Code\LogSmith\Library\PackageCache\com.unity.nuget.mono-cecil@d78732e851eb\Mono.Cecil.dll
+info: Microsoft.AspNetCore.Routing.EndpointMiddleware[1]
+      Executed endpoint 'gRPC - /UnityILPP.PostProcessing/ConfigurePostProcessors'
+info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
+      Request finished HTTP/2 POST http://ilpp/UnityILPP.PostProcessing/ConfigurePostProcessors application/grpc - - 200 - application/grpc 47.4103ms
+Starting: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Tools\netcorerun\netcorerun.exe "C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Tools\BuildPipeline\ScriptCompilationBuildProgram.exe" "Library/Bee/1900b0aE.dag.json" "Library/Bee/1900b0aE-inputdata.json" "Library\Bee\buildprogram0.traceevents"
+WorkingDir: c:/Code/LogSmith
+ExitCode: 4 Duration: 0s239ms
+Rebuilding DAG because FileSignature timestamp changed: Library/Bee/1900b0aE-inputdata.json
+[695/899    0s] ILPP-Configuration Library/ilpp-configuration.nevergeneratedoutput
+*** Tundra requires additional run (0.21 seconds), 2 items updated, 694 evaluated
+ExitCode: 0 Duration: 0s689ms
+Starting: C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\bee_backend.exe --ipc --defer-dag-verification --dagfile="Library/Bee/1900b0aE.dag" --continue-on-failure --dagfilejson="Library\Bee\1900b0aE.dag.json" --profile="Library/Bee/backend2.traceevents" ScriptAssemblies
+WorkingDir: c:/Code/LogSmith
+info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
+      Request starting HTTP/2 POST http://ilpp/UnityILPP.PostProcessing/ConfigurePostProcessors application/grpc -
+info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]
+      Executing endpoint 'gRPC - /UnityILPP.PostProcessing/ConfigurePostProcessors'
+info: Unity.ILPP.Runner.PostProcessingAssemblyLoadContext[0]
+      Current configuration matches the requested one, skipping
+info: Microsoft.AspNetCore.Routing.EndpointMiddleware[1]
+      Executed endpoint 'gRPC - /UnityILPP.PostProcessing/ConfigurePostProcessors'
+info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
+      Request finished HTTP/2 POST http://ilpp/UnityILPP.PostProcessing/ConfigurePostProcessors application/grpc - - 200 - application/grpc 1.3806ms
+info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
+      Request starting HTTP/2 POST http://ilpp/UnityILPP.PostProcessing/PostProcessAssembly application/grpc -
+info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]
+      Executing endpoint 'gRPC - /UnityILPP.PostProcessing/PostProcessAssembly'
+info: Unity.ILPP.Runner.PostProcessingPipeline[0]
+      Processing assembly Library/Bee/artifacts/1900b0aE.dag/IrsikSoftware.LogSmith.Editor.dll, with 132 defines and 273 references
+info: Unity.ILPP.Runner.PostProcessingPipeline[0]
+      processors: Unity.Jobs.CodeGen.JobsILPostProcessor, zzzUnity.Burst.CodeGen.BurstILPostProcessor
+info: Unity.ILPP.Runner.PostProcessingPipeline[0]
+      running Unity.Jobs.CodeGen.JobsILPostProcessor
+info: Unity.ILPP.Runner.PostProcessingAssemblyLoadContext[0]
+      Resolved Unity.Collections, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null with Library\Bee\artifacts\1900b0aE.dag\Unity.Collections.dll
+info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
+      Request starting HTTP/2 POST http://ilpp/UnityILPP.PostProcessing/PostProcessAssembly application/grpc -
+info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]
+      Executing endpoint 'gRPC - /UnityILPP.PostProcessing/PostProcessAssembly'
+info: Unity.ILPP.Runner.PostProcessingPipeline[0]
+      Processing assembly Library/Bee/artifacts/1900b0aE.dag/IrsikSoftware.LogSmith.Tests.Editor.dll, with 131 defines and 258 references
+info: Unity.ILPP.Runner.PostProcessingPipeline[0]
+      processors: Unity.Jobs.CodeGen.JobsILPostProcessor, zzzUnity.Burst.CodeGen.BurstILPostProcessor
+info: Unity.ILPP.Runner.PostProcessingPipeline[0]
+      running Unity.Jobs.CodeGen.JobsILPostProcessor
+info: Unity.ILPP.Runner.PostProcessingPipeline[0]
+      running zzzUnity.Burst.CodeGen.BurstILPostProcessor
+info: Microsoft.AspNetCore.Routing.EndpointMiddleware[1]
+      Executed endpoint 'gRPC - /UnityILPP.PostProcessing/PostProcessAssembly'
+info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
+      Request finished HTTP/2 POST http://ilpp/UnityILPP.PostProcessing/PostProcessAssembly application/grpc - - 200 - application/grpc 5.3019ms
+info: Unity.ILPP.Runner.PostProcessingAssemblyLoadContext[0]
+      Resolved UnityEditor.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null with C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Managed\UnityEngine\UnityEditor.CoreModule.dll
+info: Unity.ILPP.Runner.PostProcessingAssemblyLoadContext[0]
+      Resolved UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null with C:\Program Files\Unity\Hub\Editor\6000.2.5f1\Editor\Data\Managed\UnityEngine\UnityEngine.CoreModule.dll
+info: Unity.ILPP.Runner.PostProcessingPipeline[0]
+      running zzzUnity.Burst.CodeGen.BurstILPostProcessor
+info: Unity.ILPP.Runner.PostProcessingAssemblyLoadContext[0]
+      Resolved Unity.Burst.Cecil.Rocks, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e with C:\Code\LogSmith\Library\PackageCache\com.unity.burst@f7a407abf4d5\Unity.Burst.CodeGen\Unity.Burst.Cecil.Rocks.dll
+info: Microsoft.AspNetCore.Routing.EndpointMiddleware[1]
+      Executed endpoint 'gRPC - /UnityILPP.PostProcessing/PostProcessAssembly'
+info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
+      Request finished HTTP/2 POST http://ilpp/UnityILPP.PostProcessing/PostProcessAssembly application/grpc - - 200 - application/grpc 549.4067ms
+ExitCode: 0 Duration: 1s316ms
+Finished compiling graph: 902 nodes, 15424 flattened edges (12970 ToBuild, 146 ToUse), maximum node priority 974
+[501/899    0s] WriteText Library/Bee/artifacts/1900b0aE.dag/IrsikSoftware.LogSmith.Editor.rsp
+[695/899    0s] ILPP-Configuration Library/ilpp-configuration.nevergeneratedoutput
+[891/899    0s] Csc Library/Bee/artifacts/1900b0aE.dag/IrsikSoftware.LogSmith.Editor.dll (+2 others)
+[           0s] Csc Library/Bee/artifacts/1900b0aE.dag/IrsikSoftware.LogSmith.Editor.dll (+2 others) [CacheWrite 00000000000000000000000000000005]
+[892/899    0s] Csc Library/Bee/artifacts/1900b0aE.dag/IrsikSoftware.LogSmith.Tests.Editor.dll (+2 others)
+[           0s] Csc Library/Bee/artifacts/1900b0aE.dag/IrsikSoftware.LogSmith.Tests.Editor.dll (+2 others) [CacheWrite 00000000000000000000000000000005]
+[893/899    0s] ILPostProcess Library/Bee/artifacts/1900b0aE.dag/post-processed/IrsikSoftware.LogSmith.Tests.Editor.dll (+pdb)
+Processing assembly Library/Bee/artifacts/1900b0aE.dag/IrsikSoftware.LogSmith.Tests.Editor.dll, with 131 defines and 258 references
+
+processors: Unity.Jobs.CodeGen.JobsILPostProcessor, zzzUnity.Burst.CodeGen.BurstILPostProcessor
+
+running Unity.Jobs.CodeGen.JobsILPostProcessor
+
+running zzzUnity.Burst.CodeGen.BurstILPostProcessor
+[894/899    0s] CopyFiles Library/ScriptAssemblies/IrsikSoftware.LogSmith.Tests.Editor.pdb
+[895/899    0s] CopyFiles Library/ScriptAssemblies/IrsikSoftware.LogSmith.Tests.Editor.dll
+[896/899    0s] ILPostProcess Library/Bee/artifacts/1900b0aE.dag/post-processed/IrsikSoftware.LogSmith.Editor.dll (+pdb)
+Processing assembly Library/Bee/artifacts/1900b0aE.dag/IrsikSoftware.LogSmith.Editor.dll, with 132 defines and 273 references
+
+processors: Unity.Jobs.CodeGen.JobsILPostProcessor, zzzUnity.Burst.CodeGen.BurstILPostProcessor
+
+running Unity.Jobs.CodeGen.JobsILPostProcessor
+
+running zzzUnity.Burst.CodeGen.BurstILPostProcessor
+[897/899    0s] CopyFiles Library/ScriptAssemblies/IrsikSoftware.LogSmith.Editor.pdb
+[898/899    0s] CopyFiles Library/ScriptAssemblies/IrsikSoftware.LogSmith.Editor.dll
+*** Tundra build success (1.30 seconds), 10 items updated, 899 evaluated
+AssetDatabase: script compilation time: 2.624251s
+Begin MonoManager ReloadAssembly
+- Loaded All Assemblies, in  7.641 seconds
+Refreshing native plugins compatible for Editor in 1.13 ms, found 3 plugins.
+Native extension for WindowsStandalone target not found
+Mono: successfully reloaded assembly
+- Finished resetting the current domain, in  3.086 seconds
+Domain Reload Profiling: 10724ms
+	BeginReloadAssembly (288ms)
+		ExecutionOrderSort (0ms)
+		DisableScriptedObjects (13ms)
+		BackupInstance (0ms)
+		ReleaseScriptingObjects (0ms)
+		CreateAndSetChildDomain (145ms)
+	RebuildCommonClasses (36ms)
+	RebuildNativeTypeToScriptingClass (13ms)
+	initialDomainReloadingComplete (29ms)
+	LoadAllAssembliesAndSetupDomain (7272ms)
+		LoadAssemblies (7137ms)
+		RebuildTransferFunctionScriptingTraits (0ms)
+		AnalyzeDomain (225ms)
+			TypeCache.Refresh (165ms)
+				TypeCache.ScanAssembly (155ms)
+			BuildScriptInfoCaches (47ms)
+			ResolveRequiredComponents (10ms)
+	FinalizeReload (3087ms)
+		ReleaseScriptCaches (0ms)
+		RebuildScriptCaches (0ms)
+		SetupLoadedEditorAssemblies (2807ms)
+			LogAssemblyErrors (0ms)
+			InitializePlatformSupportModulesInManaged (20ms)
+			SetLoadedEditorAssemblies (3ms)
+			BeforeProcessingInitializeOnLoad (151ms)
+			ProcessInitializeOnLoadAttributes (2563ms)
+			ProcessInitializeOnLoadMethodAttributes (64ms)
+			AfterProcessingInitializeOnLoad (6ms)
+			EditorAssembliesLoaded (0ms)
+		ExecutionOrderSort2 (0ms)
+		AwakeInstancesAfterBackupRestoration (13ms)
+Refreshing native plugins compatible for Editor in 1.01 ms, found 3 plugins.
+Preloading 0 native plugins for Editor in 0.00 ms.
+Asset Pipeline Refresh (id=9e6fbd27697780347bd32c87e8074dc1): Total: 14.510 seconds - Initiated by InitialRefreshV2(ForceSynchronousImport)
+	Summary:
+		Imports: total=0 (actual=0, local cache=0, cache server=0)
+		Asset DB Process Time: managed=0 ms, native=3520 ms
+		Asset DB Callback time: managed=644 ms, native=20 ms
+		Scripting: domain reloads=1, domain reload time=7641 ms, compile time=2627 ms, other=56 ms
+		Project Asset Count: scripts=1263, non-scripts=2113
+		Asset File Changes: new=1, changed=1, moved=0, deleted=2
+		Scan Filter Count: 0
+	InvokeCustomDependenciesCallbacks: 0.001ms
+	InvokePackagesCallback: 16.709ms
+	ApplyChangesToAssetFolders: 0.666ms
+	Scan: 129.965ms
+	OnSourceAssetsModified: 0.793ms
+	CategorizeAssetsWithTransientArtifact: 53.701ms
+	ProcessAssetsWithTransientArtifactChanges: 70.354ms
+	UnregisterDeletedAssets: 0.002ms
+	CategorizeAssets: 40.801ms
+	ImportOutOfDateAssets: 3095.561ms (467.692ms without children)
+		CompileScripts: 2626.630ms
+		ReloadNativeAssets: 0.001ms
+		UnloadImportedAssets: 0.130ms
+		EnsureUptoDateAssetsAreRegisteredWithGuidPM: 0.566ms
+		InitializingProgressBar: 0.001ms
+		PostProcessAllAssetNotificationsAddChangedAssets: 0.003ms
+		OnDemandSchedulerStart: 0.540ms
+	PostProcessAllAssets: 645.563ms
+	Hotreload: 3.501ms
+	GatherAllCurrentPrimaryArtifactRevisions: 0.002ms
+	UnloadStreamsBegin: 1.145ms
+	PersistCurrentRevisions: 0.102ms
+	UnloadStreamsEnd: 0.002ms
+	GenerateScriptTypeHashes: 3.301ms
+	Untracked: 10451.585ms
+
+Application.AssetDatabase Initial Refresh End
+Scanning for USB devices : 5.207ms
+Initializing Unity extensions:
+[MODES] ModeService[none].Initialize
+[MODES] ModeService[none].LoadModes
+[MODES] Loading mode Default (0) for mode-current-id-LogSmith
+Unloading 111 Unused Serialized files (Serialized files now loaded: 0)
+Unloading 6342 unused Assets / (2.9 MB). Loaded Objects now: 7031.
+Memory consumption went from 185.9 MB to 182.9 MB.
+Total: 9.749400 ms (FindLiveObjects: 0.815000 ms CreateObjectMapping: 0.330600 ms MarkObjects: 6.431000 ms  DeleteObjects: 2.171900 ms)
+
+[SampleSceneGenerator] Starting scene generation...
+UnityEngine.Debug:ExtractStackTraceNoAlloc (byte*,int,string)
+UnityEngine.StackTraceUtility:ExtractStackTrace ()
+UnityEngine.DebugLogHandler:Internal_Log (UnityEngine.LogType,UnityEngine.LogOption,string,UnityEngine.Object)
+UnityEngine.DebugLogHandler:LogFormat (UnityEngine.LogType,UnityEngine.Object,string,object[])
+UnityEngine.Logger:Log (UnityEngine.LogType,object)
+UnityEngine.Debug:Log (object)
+IrsikSoftware.LogSmith.Editor.SampleSceneGenerator:GenerateAllScenes () (at C:/Code/LogSmith/Packages/com.irsiksoftware.logsmith/Editor/SampleSceneGenerator.cs:17)
+
+(Filename: C:/Code/LogSmith/Packages/com.irsiksoftware.logsmith/Editor/SampleSceneGenerator.cs Line: 17)
+
+Unloading 3 Unused Serialized files (Serialized files now loaded: 0)
+Unloading 1 unused Assets / (42.6 KB). Loaded Objects now: 7044.
+Memory consumption went from 167.6 MB to 167.6 MB.
+Total: 6.992000 ms (FindLiveObjects: 0.223300 ms CreateObjectMapping: 0.137100 ms MarkObjects: 6.609200 ms  DeleteObjects: 0.021800 ms)
+
+Asset Pipeline Refresh (id=335a8ef2259f9f34aae7775e0051ebca): Total: 0.033 seconds - Initiated by StopAssetImportingV2(NoUpdateAssetOptions)
+[SampleSceneGenerator] Built-in scene created: Packages/com.irsiksoftware.logsmith/Samples~/Built-in/BuiltInDemo.unity
+UnityEngine.Debug:ExtractStackTraceNoAlloc (byte*,int,string)
+UnityEngine.StackTraceUtility:ExtractStackTrace ()
+UnityEngine.DebugLogHandler:Internal_Log (UnityEngine.LogType,UnityEngine.LogOption,string,UnityEngine.Object)
+UnityEngine.DebugLogHandler:LogFormat (UnityEngine.LogType,UnityEngine.Object,string,object[])
+UnityEngine.Logger:Log (UnityEngine.LogType,object)
+UnityEngine.Debug:Log (object)
+IrsikSoftware.LogSmith.Editor.SampleSceneGenerator:GenerateScene (string,string) (at C:/Code/LogSmith/Packages/com.irsiksoftware.logsmith/Editor/SampleSceneGenerator.cs:91)
+IrsikSoftware.LogSmith.Editor.SampleSceneGenerator:GenerateAllScenes () (at C:/Code/LogSmith/Packages/com.irsiksoftware.logsmith/Editor/SampleSceneGenerator.cs:19)
+
+(Filename: C:/Code/LogSmith/Packages/com.irsiksoftware.logsmith/Editor/SampleSceneGenerator.cs Line: 91)
+
+Unloading 12 Unused Serialized files (Serialized files now loaded: 0)
+Unloading 15 unused Assets / (320.8 KB). Loaded Objects now: 7049.
+Memory consumption went from 172.9 MB to 172.6 MB.
+Total: 7.331700 ms (FindLiveObjects: 0.222900 ms CreateObjectMapping: 0.138200 ms MarkObjects: 6.658100 ms  DeleteObjects: 0.311800 ms)
+
+Asset Pipeline Refresh (id=df6a8e29b9b1b23438ed11994f238fde): Total: 0.010 seconds - Initiated by StopAssetImportingV2(NoUpdateAssetOptions)
+[SampleSceneGenerator] URP scene created: Packages/com.irsiksoftware.logsmith/Samples~/URP/URPDemo.unity
+UnityEngine.Debug:ExtractStackTraceNoAlloc (byte*,int,string)
+UnityEngine.StackTraceUtility:ExtractStackTrace ()
+UnityEngine.DebugLogHandler:Internal_Log (UnityEngine.LogType,UnityEngine.LogOption,string,UnityEngine.Object)
+UnityEngine.DebugLogHandler:LogFormat (UnityEngine.LogType,UnityEngine.Object,string,object[])
+UnityEngine.Logger:Log (UnityEngine.LogType,object)
+UnityEngine.Debug:Log (object)
+IrsikSoftware.LogSmith.Editor.SampleSceneGenerator:GenerateScene (string,string) (at C:/Code/LogSmith/Packages/com.irsiksoftware.logsmith/Editor/SampleSceneGenerator.cs:91)
+IrsikSoftware.LogSmith.Editor.SampleSceneGenerator:GenerateAllScenes () (at C:/Code/LogSmith/Packages/com.irsiksoftware.logsmith/Editor/SampleSceneGenerator.cs:20)
+
+(Filename: C:/Code/LogSmith/Packages/com.irsiksoftware.logsmith/Editor/SampleSceneGenerator.cs Line: 91)
+
+Unloading 11 Unused Serialized files (Serialized files now loaded: 0)
+Unloading 15 unused Assets / (320.6 KB). Loaded Objects now: 7049.
+Memory consumption went from 176.5 MB to 176.2 MB.
+Total: 7.390000 ms (FindLiveObjects: 0.396900 ms CreateObjectMapping: 0.166600 ms MarkObjects: 6.458200 ms  DeleteObjects: 0.367500 ms)
+
+Asset Pipeline Refresh (id=6f0165f5cbe2fd146a8f62b2f929fb73): Total: 0.010 seconds - Initiated by StopAssetImportingV2(NoUpdateAssetOptions)
+[SampleSceneGenerator] HDRP scene created: Packages/com.irsiksoftware.logsmith/Samples~/HDRP/HDRPDemo.unity
+UnityEngine.Debug:ExtractStackTraceNoAlloc (byte*,int,string)
+UnityEngine.StackTraceUtility:ExtractStackTrace ()
+UnityEngine.DebugLogHandler:Internal_Log (UnityEngine.LogType,UnityEngine.LogOption,string,UnityEngine.Object)
+UnityEngine.DebugLogHandler:LogFormat (UnityEngine.LogType,UnityEngine.Object,string,object[])
+UnityEngine.Logger:Log (UnityEngine.LogType,object)
+UnityEngine.Debug:Log (object)
+IrsikSoftware.LogSmith.Editor.SampleSceneGenerator:GenerateScene (string,string) (at C:/Code/LogSmith/Packages/com.irsiksoftware.logsmith/Editor/SampleSceneGenerator.cs:91)
+IrsikSoftware.LogSmith.Editor.SampleSceneGenerator:GenerateAllScenes () (at C:/Code/LogSmith/Packages/com.irsiksoftware.logsmith/Editor/SampleSceneGenerator.cs:21)
+
+(Filename: C:/Code/LogSmith/Packages/com.irsiksoftware.logsmith/Editor/SampleSceneGenerator.cs Line: 91)
+
+Asset Pipeline Refresh (id=3421e0cb735ea3844afcc12e202f80aa): Total: 0.009 seconds - Initiated by RefreshV2(NoUpdateAssetOptions)
+[SampleSceneGenerator] All sample scenes generated successfully!
+UnityEngine.Debug:ExtractStackTraceNoAlloc (byte*,int,string)
+UnityEngine.StackTraceUtility:ExtractStackTrace ()
+UnityEngine.DebugLogHandler:Internal_Log (UnityEngine.LogType,UnityEngine.LogOption,string,UnityEngine.Object)
+UnityEngine.DebugLogHandler:LogFormat (UnityEngine.LogType,UnityEngine.Object,string,object[])
+UnityEngine.Logger:Log (UnityEngine.LogType,object)
+UnityEngine.Debug:Log (object)
+IrsikSoftware.LogSmith.Editor.SampleSceneGenerator:GenerateAllScenes () (at C:/Code/LogSmith/Packages/com.irsiksoftware.logsmith/Editor/SampleSceneGenerator.cs:26)
+
+(Filename: C:/Code/LogSmith/Packages/com.irsiksoftware.logsmith/Editor/SampleSceneGenerator.cs Line: 26)
+
+Batchmode quit successfully invoked - shutting down!
+[Physics::Module] Cleanup current backend.
+[Physics::Module] Id: 0xf2b8ea05
+Input System module state changed to: ShutdownInProgress.
+Input System polling thread exited.
+Input System module state changed to: Shutdown.
+[Licensing::IpcConnector] LicenseClient-Ender-notifications channel disconnected successfully.
+[Licensing::IpcConnector] LicenseClient-Ender channel disconnected successfully.
+AcceleratorClientConnectionCallback - disconnected - :0
+Cleanup mono
+abort_threads: Failed aborting id: 0000000000008A48, mono_thread_manage will ignore it
+
+abort_threads: Failed aborting id: 00000000000060EC, mono_thread_manage will ignore it
+
+abort_threads: Failed aborting id: 0000000000008A48, mono_thread_manage will ignore it
+
+abort_threads: Failed aborting id: 00000000000060EC, mono_thread_manage will ignore it
+
+debugger-agent: Unable to listen on 3180
+Exiting batchmode successfully now!
+Exiting without the bug reporter. Application will terminate with return code 0


### PR DESCRIPTION
## Summary
- Created comprehensive Third Party Notices.md documenting all package dependencies
- Documented Unity Companion License packages (com.unity.logging, burst, collections)
- Documented optional VContainer MIT license with full license text
- Added export compliance statement
- ASSET_STORE_METADATA.md (created in previous work) contains complete store description, platform support, and policies

## What
Added legal attribution and compliance documentation required for Asset Store submission per issue #29 acceptance criteria.

## Why
- Satisfies Unity Asset Store legal requirements
- Ensures compliance with third-party dependency licenses
- Provides transparency to users about what packages LogSmith depends on
- Required for successful Asset Store submission approval

## Implementation Notes
- Third Party Notices.md placed in package root following Unity package conventions
- All dependencies from package.json are documented with license types and URLs
- VContainer (optional dependency) includes full MIT license text
- Unity packages reference Unity Companion License
- Contact information aligned with ASSET_STORE_METADATA.md
- Export compliance confirmed (no encryption restrictions)

## Test Plan
- [x] Manual review: Third Party Notices.md contains all dependencies from package.json
- [x] Manual review: All license types correctly identified
- [x] Manual review: Unity Companion License properly referenced
- [x] Manual review: VContainer MIT license text included
- [x] Manual review: ASSET_STORE_METADATA.md support/contact info complete
- [x] Manual review: Export compliance statement present

## Acceptance Checklist
- [x] Store description, bullets written (ASSET_STORE_METADATA.md)
- [x] Supported versions/platforms documented (ASSET_STORE_METADATA.md)
- [x] Support policies documented (ASSET_STORE_METADATA.md)
- [x] Legal attributions created (Third Party Notices.md)
- [x] Support/contact info provided (both files)
- [x] Draft ready for submission review

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)